### PR TITLE
Enable drkonqi-coredump-launcher to run for non-system _and_ root users.

### DIFF
--- a/src/coredump/launcher/drkonqi-coredump-launcher.socket
+++ b/src/coredump/launcher/drkonqi-coredump-launcher.socket
@@ -4,7 +4,8 @@
 [Unit]
 Description=Socket to launch DrKonqi for a systemd-coredump crash
 DefaultDependencies=no
-ConditionUser=!@system
+ConditionUser=|!@system
+ConditionUser=|root
 
 [Socket]
 # This is a bit problematic. Technically the user should be able to set the runtime dir via env as well, but we need

--- a/src/coredump/launcher/drkonqi-coredump-launcher@.service.cmake
+++ b/src/coredump/launcher/drkonqi-coredump-launcher@.service.cmake
@@ -4,7 +4,8 @@
 [Unit]
 Description=Launch DrKonqi for a systemd-coredump crash
 PartOf=graphical-session.target
-ConditionUser=!@system
+ConditionUser=|!@system
+ConditionUser=|root
 
 [Service]
 # Don't need to be working anywhere specific, use tmp.

--- a/src/coredump/processor/drkonqi-coredump-pickup.service.cmake
+++ b/src/coredump/processor/drkonqi-coredump-pickup.service.cmake
@@ -7,7 +7,8 @@ PartOf=graphical-session.target
 Requires=drkonqi-coredump-launcher.socket
 After=plasma-core.target
 After=drkonqi-coredump-launcher.socket
-ConditionUser=!@system
+ConditionUser=|!@system
+ConditionUser=|root
 
 [Service]
 ExecStart=@KDE_INSTALL_FULL_LIBEXECDIR@/drkonqi-coredump-processor --settle-first --pickup --uid %U


### PR DESCRIPTION
Enable drkonqi-coredump-launcher to run for non-system _and_ root users.
IE: [KDE Bug 502960](https://bugs.kde.org/show_bug.cgi?id=502960)

This patch affects the _intent_ of commit [7dca985](https://github.com/KDE/drkonqi/commit/7dca985d21d76a98b4d39196404060c928afb9f4) while allowing downstream consumers of the product to _continue_ to implement it under their 'root' system user -- an established practice.

> 🗒️ This PR is backlinked from the KDE bug.